### PR TITLE
Further investigation of build

### DIFF
--- a/test-variants/blocks/date_of_birth.jsonnet
+++ b/test-variants/blocks/date_of_birth.jsonnet
@@ -1,0 +1,53 @@
+local placeholders = import '../lib/placeholders.libsonnet';
+
+local Question(title) = {
+    "id": "date-of-birth-question",
+    "type": "General",
+    "title": title,
+    "answers": [
+        {
+            "id": "date-of-birth-answer",
+            "mandatory": true,
+            "type": "Date",
+            "maximum": {
+                "value": "now"
+            },
+            "minimum": {
+                "value": "1900-01-01"
+            }
+        }
+    ]
+};
+
+local nonProxyTitle = "What is your age?";
+local proxyTitle = {
+    "text": "What age is <em>{person_name}</em>?",
+    "placeholders": [
+        placeholders.PersonName
+    ]
+};
+
+{
+    "type": "Question",
+    "id": "date-of-birth",
+    "questions": [
+        { 
+            "question": Question(nonProxyTitle),
+            "when": [{
+                "id": "proxy-answer",
+                "condition": "equals",
+                "value": "non-proxy"
+            }]
+
+        },
+        {
+            "question": Question(proxyTitle),
+            "when": [{
+                "id": "proxy-answer",
+                "condition": "equals",
+                "value": "proxy"
+            }]
+        }
+    ],
+    "routing_rules": "default"
+}

--- a/test-variants/lib/placeholders.libsonnet
+++ b/test-variants/lib/placeholders.libsonnet
@@ -1,0 +1,15 @@
+{
+    PersonName: {
+        "placeholder": "person_name",
+        "transforms": [{
+            "transform": "concatenate_list",
+            "arguments": {
+                "list_to_concatenate": {
+                    "source": "answers",
+                    "identifier": ["first-name-answer", "last-name-answer"]
+                },
+                "delimiter": " "
+            }
+        }]
+    }
+}

--- a/test-variants/test_variants.jsonnet
+++ b/test-variants/test_variants.jsonnet
@@ -1,0 +1,47 @@
+local date_of_birth = import "blocks/date_of_birth.jsonnet";
+
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "census",
+    "title": "Variants Test",
+    "description": "Variants Test Schema",
+    "theme": "census",
+    "eq_id": "test",
+    "form_type": "variants",
+    "navigation": {
+        "visible": false
+    },
+    "metadata": [
+        {
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "region_code",
+            "validator": "string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "variants-section",
+            "title": "Variants Section",
+            "groups": [
+                {
+                    "id": "variants-group",
+                    "blocks": [
+                        date_of_birth,
+                        date_of_birth + {
+                            "routing_rules": "undefined"
+                        },
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Further investigation into the finer points of using jsonnet to build schemas. This pull request covers:

- How will variants work?
  Use a function to template the common structure, see `date_of_birth.jsonnet`.

- How will routing rules be defined?
  Until we know how much variation there will be we will leave it on each block definition. If we need to override it per survey you can do so by merging it with a custom routing rule in the top level json, see `test_variants.jsonnet`.

- How will we share duplicated placeholder json?
  Creating a shared libsonnet file and importing it, see `placeholders.libsonnet`.

To test, run `jsonnet test-variants/test_variants.jsonnet`. 